### PR TITLE
Migrate to Flet 0.8 architecture

### DIFF
--- a/examples/flet_dropzone_example/pyproject.toml
+++ b/examples/flet_dropzone_example/pyproject.toml
@@ -3,13 +3,13 @@ name = "flet-dropzone-example"
 version = "1.0.0"
 description = ""
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "KOGA Mitsuhiro", email = "shiena.jp@gmail.com" }
 ]
 dependencies = [
   "flet-dropzone @ git+https://github.com/shiena/flet-dropzone.git",
-  "flet>=0.26.0",
+  "flet>=0.80.0",
 ]
 
 [tool.flet]
@@ -32,8 +32,8 @@ path = "src"
 
 [tool.uv]
 dev-dependencies = [
-    "flet[all]>=0.26.0",
+    "flet[all]>=0.80.0",
 ]
 
 [tool.poetry.group.dev.dependencies]
-flet = {extras = ["all"], version = ">=0.26.0"}
+flet = {extras = ["all"], version = ">=0.80.0"}

--- a/examples/flet_dropzone_example/src/main.py
+++ b/examples/flet_dropzone_example/src/main.py
@@ -13,7 +13,7 @@ def main(page: ft.Page):
                 ft.Text("Drop here!"),
                 width=500,
                 height=500,
-                alignment=ft.alignment.center,
+                alignment=ft.Alignment.CENTER,
                 bgcolor="red",
             ),
             on_dropped=lambda e: print(f"Dropped: {e.files}"),
@@ -23,4 +23,4 @@ def main(page: ft.Page):
     )
 
 
-ft.app(main)
+ft.run(main)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "flet-dropzone"
-version = "0.2.0"
+version = "0.3.0"
 description = "Dropzone control for Flet"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "KOGA Mitsuhiro", email = "shiena.jp@gmail.com" }
 ]
@@ -11,7 +11,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-    "flet>=0.26.0",
+    "flet>=0.80.0",
 ]
 
 [project.urls]
@@ -25,11 +25,11 @@ Issues = "https://github.com/shiena/flet-dropzone/issues"
 
 [tool.uv]
 dev-dependencies = [
-    "flet[all]>=0.26.0",
+    "flet[all]>=0.80.0",
 ]
 
 [tool.poetry.group.dev.dependencies]
-flet = {extras = ["all"], version = ">=0.26.0"}
+flet = {extras = ["all"], version = ">=0.80.0"}
 
 [tool.setuptools]
 license-files = []

--- a/src/flet_dropzone/__init__.py
+++ b/src/flet_dropzone/__init__.py
@@ -1,1 +1,1 @@
-from flet_dropzone.flet_dropzone import Dropzone
+from flet_dropzone.flet_dropzone import Dropzone, DropzoneEvent

--- a/src/flutter/flet_dropzone/lib/flet_dropzone.dart
+++ b/src/flutter/flet_dropzone/lib/flet_dropzone.dart
@@ -1,3 +1,8 @@
 library flet_dropzone;
 
-export "../src/create_control.dart" show createControl, ensureInitialized;
+import "src/create_control.dart";
+
+export "src/create_control.dart" show FletDropzoneExtension;
+
+// Alias for Flet build template compatibility
+typedef Extension = FletDropzoneExtension;

--- a/src/flutter/flet_dropzone/lib/src/create_control.dart
+++ b/src/flutter/flet_dropzone/lib/src/create_control.dart
@@ -1,23 +1,28 @@
 import 'package:flet/flet.dart';
+import 'package:flutter/widgets.dart';
 
 import 'flet_dropzone.dart';
 
-CreateControlFactory createControl = (CreateControlArgs args) {
-  switch (args.control.type) {
-    case "flet_dropzone":
-      return DropzoneControl(
-        parent: args.parent,
-        control: args.control,
-        children: args.children,
-        parentDisabled: args.parentDisabled,
-        parentAdaptive: args.parentAdaptive,
-        backend: args.backend,
-      );
-    default:
-      return null;
+class FletDropzoneExtension extends FletExtension {
+  @override
+  void ensureInitialized() {
+    // nothing to initialize
   }
-};
 
-void ensureInitialized() {
-  // nothing to initialize
+  @override
+  Widget? createWidget(Key? key, Control control) {
+    switch (control.type) {
+      case "flet_dropzone":
+        return DropzoneControl(key: key, control: control);
+      default:
+        return null;
+    }
+  }
 }
+
+// Keep old API for backward compatibility (deprecated)
+@Deprecated('Use FletDropzoneExtension instead')
+typedef CreateControlFactory = Widget? Function(dynamic args);
+
+@Deprecated('Use FletDropzoneExtension instead')
+CreateControlFactory createControl = (_) => null;

--- a/src/flutter/flet_dropzone/pubspec.yaml
+++ b/src/flutter/flet_dropzone/pubspec.yaml
@@ -1,16 +1,16 @@
 name: flet_dropzone
 description: Flet Dropzone control
 repository: https://github.com/shiena/flet-dropzone/src/flutter/flet_dropzone
-version: 0.1.0
+version: 0.3.0
 homepage: https://github.com/shiena/flet-dropzone
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
   flutter: ">=1.17.0"
 
 dependencies:
   desktop_drop: ^0.5.0
-  flet: 0.27.0
+  flet: ^0.80.0
   flutter:
     sdk: flutter
 
@@ -18,4 +18,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.0
-  


### PR DESCRIPTION
Fix #3 

Breaking changes for Flet 0.8 compatibility:

Python:
- Use @control decorator with dataclass pattern
- Replace ConstrainedControl with LayoutControl
- Update imports to flet.controls.*
- Add DropzoneEvent dataclass for typed events

Dart/Flutter:
- Implement FletExtension interface
- Add Extension typedef for build template compatibility
- Use control.triggerEvent() and control.buildWidget() APIs
- Wrap with LayoutControl widget

Dependencies:
- Bump version to 0.3.0
- Require flet>=0.80.0
- Require Python>=3.10

Example:
- Update to use ft.run() and ft.Alignment.CENTER
- Reference flet-dropzone>=0.3.0 from PyPI