### PR TITLE
Cleanup and improvements after Flet 0.8 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ def main(page: ft.Page):
                 ft.Text("Drop here!"),
                 width=500,
                 height=500,
-                alignment=ft.alignment.center,
+                alignment=ft.Alignment.CENTER,
                 bgcolor="red",
             ),
             on_dropped=lambda e: print(f"Dropped: {e.files}"),
@@ -62,7 +62,7 @@ def main(page: ft.Page):
     )
 
 
-ft.app(main)
+ft.run(main)
 ```
 
 ## References

--- a/examples/flet_dropzone_example/pyproject.toml
+++ b/examples/flet_dropzone_example/pyproject.toml
@@ -35,5 +35,7 @@ dev-dependencies = [
     "flet[all]>=0.80.0",
 ]
 
-[tool.poetry.group.dev.dependencies]
-flet = {extras = ["all"], version = ">=0.80.0"}
+[dependency-groups]
+dev = [
+    "flet[all]>=0.80.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flet-dropzone"
-version = "0.3.0"
+version = "0.3.1"
 description = "Dropzone control for Flet"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -28,8 +28,10 @@ dev-dependencies = [
     "flet[all]>=0.80.0",
 ]
 
-[tool.poetry.group.dev.dependencies]
-flet = {extras = ["all"], version = ">=0.80.0"}
+[dependency-groups]
+dev = [
+    "flet[all]>=0.80.0",
+]
 
 [tool.setuptools]
 license-files = []

--- a/src/flutter/flet_dropzone/lib/src/create_control.dart
+++ b/src/flutter/flet_dropzone/lib/src/create_control.dart
@@ -19,10 +19,3 @@ class FletDropzoneExtension extends FletExtension {
     }
   }
 }
-
-// Keep old API for backward compatibility (deprecated)
-@Deprecated('Use FletDropzoneExtension instead')
-typedef CreateControlFactory = Widget? Function(dynamic args);
-
-@Deprecated('Use FletDropzoneExtension instead')
-CreateControlFactory createControl = (_) => null;


### PR DESCRIPTION
## Summary

- Migrate dev dependencies from Poetry format to PEP 735 `[dependency-groups]` for better tool interoperability
- Update README example code to use Flet 0.8 API (`ft.run()`, `ft.Alignment.CENTER`)
- Remove deprecated `CreateControlFactory` and `createControl` from Dart code (no longer needed with `FletExtension`)

## Test plan

- [ ] Verify `uv sync` works with new dependency-groups format
- [ ] Confirm README example code compiles with Flet 0.8
- [ ] Build example app with `flet build windows` to ensure Dart changes work